### PR TITLE
Updating sponsor fields to be optional per the new memberization process. Fixes #4

### DIFF
--- a/src/controllers.php
+++ b/src/controllers.php
@@ -85,14 +85,14 @@ $app->match('/apply', function (Request $request) use ($app) {
       'constraints' => [],
     ])
     ->add('sponsor', 'text', [
-      'label' => 'Name of sponsoring member *',
-      'attr' => [ 'placeholder' => 'Ada Lovelace' ],
-      'constraints' => [ new Assert\NotBlank() ],
+      'label' => 'Name of sponsoring member',
+      'attr' => [ 'placeholder' => 'None' ],
+      'constraints' => [ ],
     ])
     ->add('second_sponsor', 'text', [
-      'label' => 'Seconding member? *',
-      'attr' => [ 'placeholder' => 'Alan Turing' ],
-      'constraints' => [ new Assert\NotBlank() ],
+      'label' => 'Seconding member?',
+      'attr' => [ 'placeholder' => 'None' ],
+      'constraints' => [ ],
     ])
     ->add('twitter', 'text', [
       'label' => 'Twitter',


### PR DESCRIPTION
Change also requires SQL execution since there are no formal migrations yet:
ALTER TABLE applicants MODIFY COLUMN sponsor varchar(255);
ALTER TABLE applicants MODIFY COLUMN second_sponsor varchar(255);
